### PR TITLE
add subscription plan creation with input validation and plan ID tracking

### DIFF
--- a/contracts/TokenTier.clar
+++ b/contracts/TokenTier.clar
@@ -1,15 +1,74 @@
+;; Subscription Service Contract
 
-;; TokenTier
-;; <add a description here>
+;; Constants
+(define-constant CONTRACT-OWNER tx-sender)
+(define-constant ERR-OWNER-ONLY (err u100))
+(define-constant ERR-NOT-FOUND (err u101))
+(define-constant ERR-ALREADY-EXISTS (err u102))
+(define-constant ERR-INSUFFICIENT-BALANCE (err u103))
+(define-constant ERR-EXPIRED (err u104))
+(define-constant ERR-INVALID-INPUT (err u105))
 
-;; constants
-;;
+;; Data maps
+(define-map subscription-plans
+  { plan-id: uint }
+  { plan-name: (string-ascii 50), subscription-duration: uint, plan-price: uint }
+)
 
-;; data maps and vars
-;;
+(define-map user-subscriptions
+  { subscriber: principal }
+  { subscribed-plan-id: uint, subscription-start-block: uint, subscription-end-block: uint }
+)
 
-;; private functions
-;;
+;; Variables
+(define-data-var next-available-plan-id uint u1)
 
-;; public functions
-;;
+;; Read-only functions
+(define-read-only (get-subscription-plan (plan-id uint))
+  (map-get? subscription-plans { plan-id: plan-id })
+)
+
+(define-read-only (get-user-subscription-details (subscriber principal))
+  (map-get? user-subscriptions { subscriber: subscriber })
+)
+
+(define-read-only (is-subscription-active (subscriber principal))
+  (match (get-user-subscription-details subscriber)
+    subscription-details (> (get subscription-end-block subscription-details) block-height)
+    false
+  )
+)
+
+;; Private functions
+(define-private (transfer-stx-tokens (amount uint) (sender principal) (recipient principal))
+  (match (stx-transfer? amount sender recipient)
+    transfer-success (ok true)
+    transfer-error (err transfer-error)
+  )
+)
+
+(define-private (validate-plan-input (plan-name (string-ascii 50)) (subscription-duration uint) (plan-price uint))
+  (and
+    (> (len plan-name) u0)
+    (< (len plan-name) u51)
+    (> subscription-duration u0)
+    (> plan-price u0)
+  )
+)
+
+;; Public functions
+(define-public (add-subscription-plan (plan-name (string-ascii 50)) (subscription-duration uint) (plan-price uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-OWNER-ONLY)
+    (asserts! (validate-plan-input plan-name subscription-duration plan-price) ERR-INVALID-INPUT)
+    (let ((new-plan-id (var-get next-available-plan-id)))
+      (asserts! (is-none (get-subscription-plan new-plan-id)) ERR-ALREADY-EXISTS)
+      (map-set subscription-plans
+        { plan-id: new-plan-id }
+        { plan-name: plan-name, subscription-duration: subscription-duration, plan-price: plan-price }
+      )
+      (var-set next-available-plan-id (+ new-plan-id u1))
+      (ok new-plan-id)
+    )
+  )
+)


### PR DESCRIPTION
---

### Title:  
**Implement Core Subscription Plan Creation Logic**

---

### Summary:  
This pull request introduces the core logic for **adding new subscription plans** to the smart contract. The functionality enables the contract owner to define new plans with custom parameters such as plan name, duration, and price. The implementation ensures that each plan has a unique identifier and that all input parameters are validated before being stored on-chain.

---

### Changes Made:

1. **Public Function: `add-subscription-plan`**
   - Allows only the `CONTRACT-OWNER` to add a new subscription plan.
   - Takes three parameters: 
     - `plan-name` (string-ascii 50)
     - `subscription-duration` (uint)
     - `plan-price` (uint)
   - Ensures:
     - Plan name is non-empty and within character limits.
     - Duration and price are greater than zero.
     - Plan ID is unique before creation.
   - Auto-increments the plan ID using the `next-available-plan-id` data variable.
   - Stores the plan in the `subscription-plans` map.

2. **Private Function: `validate-plan-input`**
   - Internal utility function to enforce input validation for plan name, duration, and price.

3. **Constants Used:**
   - `ERR-OWNER-ONLY` – ensures only contract owner can invoke the function.
   - `ERR-INVALID-INPUT` – triggers if any input parameter is invalid.
   - `ERR-ALREADY-EXISTS` – prevents overwriting an existing plan ID.

4. **State Variables:**
   - `next-available-plan-id` – a `uint` counter starting at `u1`, incremented with each new plan.

5. **Data Maps:**
   - `subscription-plans` – stores plan details indexed by unique plan IDs.

---

### Reason for Change:
To establish a dynamic and extensible **subscription infrastructure**, it is essential to provide the contract owner with a method to onboard multiple pricing tiers. This sets the foundation for users to subscribe to different plans based on their needs and budgets.

---